### PR TITLE
Uzuのビルドを分離

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,18 +22,10 @@ jobs:
 
     - name: Build
       env:
-        GITHUB_TOKEN: ${{ secrets.PACKAGES_AUTH }}
-        GITHUB_REPOSITORY: ${{ github.repository }}
         IMAGE_TAG: builder
-        IMAGE_VER: '1.0.0'
       run: |
-        USERNAME=$(echo ${GITHUB_REPOSITORY} | sed -e 's,\(.*\)/.*,\1,')
-        echo ${GITHUB_TOKEN} | docker login docker.pkg.github.com --username ${USERNAME} --password-stdin
-        DOCKER_IMAGE=docker.pkg.github.com/${GITHUB_REPOSITORY}/${IMAGE_TAG}:${IMAGE_VER}
-        docker pull ${DOCKER_IMAGE}
-        docker build -t ${DOCKER_IMAGE} .
-        docker run -v $(pwd)/build:/var/src/build ${DOCKER_IMAGE}
-        docker push ${DOCKER_IMAGE}
+        docker build -t ${IMAGE_TAG} .
+        docker run -v $(pwd)/build:/var/src/build ${IMAGE_TAG}
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3.6.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,4 @@
-FROM rakudo-star:2020.01-alpine
-
-RUN apk --update add \
-    curl \
-    git
-
-RUN zef install Uzu
+FROM nahcnuj/alpine-uzu:1.0.0
 
 WORKDIR /var/src
 


### PR DESCRIPTION
resolve #1 

`zef install uzu` までやったコンテナを別途作成し、それをベースにすることでビルド時間を短縮

[nahcnuj/alpine\-uzu: Docker container with Uzu, the static site generator written in Raku](https://github.com/nahcnuj/alpine-uzu)