### PR TITLE
Fix property name for Twitter Cards

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -4,7 +4,7 @@ template_engine: mustache
 theme: default
 language: ja
 host_url: https://www.nahcnuj.work
-meta_ogp:
+twitter_ogp:
   - property: twitter:card
     content: summary
   - property: twitter:site

--- a/partials/head.mustache
+++ b/partials/head.mustache
@@ -17,6 +17,9 @@
   <meta property="og:{{ property }}" content="{{ content }}">
   {{/hidden}}
   {{/i18n.meta_ogp}}
+  {{#site.twitter_ogp}}
+  <meta property="{{ property }}" content="{{ content }}">
+  {{/site.twitter_ogp}}
   <link href="https://fonts.gstatic.com/" rel="preconnect" crossorigin>
   <script src="https://kit.fontawesome.com/08f6e2d41a.js" crossorigin="anonymous"></script>
   <link href="/css/common.css" rel="stylesheet">


### PR DESCRIPTION
Prefix `og:` is unnecessary for Twitter Cards.