### PR TITLE
fix: not need to preload fontawesome css

### DIFF
--- a/themes/default/partials/head.mustache
+++ b/themes/default/partials/head.mustache
@@ -42,7 +42,6 @@
   <link rel="preload" as="image" href="{{ site.img_host_url }}/author_icon.jpg">
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap">
   <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,700;1,400;1,700&display=swap">
-  <link rel="preload" as="style" href="https://ka-f.fontawesome.com/releases/v5.15.4/css/free.min.css?token=08f6e2d41a">
   <link rel="preload" as="font" href="https://ka-f.fontawesome.com/releases/v5.15.4/webfonts/free-fa-solid-900.woff2" type="font/woff2" crossorigin="anonymous">
   <script async src="https://kit.fontawesome.com/08f6e2d41a.js" crossorigin="anonymous"></script>
   <link rel="stylesheet" href="/css/common.css">


### PR DESCRIPTION
> The resource https://ka-f.fontawesome.com/releases/v5.15.4/css/free.min.css?token=08f6e2d41a was preloaded using link preload but not used within a few seconds from the window's load event. Please make sure it has an appropriate `as` value and it is preloaded intentionally.
