### PR TITLE
Hide related articles section on index.html page

### DIFF
--- a/app/components/Article.tsx
+++ b/app/components/Article.tsx
@@ -199,12 +199,15 @@ ${'' /*<script type="text/javascript" charset="utf-8" src="https://adm.shinobi.j
 export const articleMdxRenderer = jsxRenderer(({ Layout, children, frontmatter }, c) => {
   const currentPath = c.req.path
 
+  // index.htmlページの場合は関連記事を表示しない
+  const isIndexPage = currentPath.endsWith('/index.html')
+
   // 現在のパスに基づいて適切な記事リストを選択
   const directoryKey = Object.keys(articlesByDirectory).find((key) => currentPath.startsWith(`/${key}/`)) as
     | keyof typeof articlesByDirectory
     | undefined
 
-  const relatedArticles = directoryKey ? articlesByDirectory[directoryKey] : undefined
+  const relatedArticles = !isIndexPage && directoryKey ? articlesByDirectory[directoryKey] : undefined
 
   return (
     <Layout frontmatter={frontmatter}>

--- a/app/components/RelatedArticles.tsx
+++ b/app/components/RelatedArticles.tsx
@@ -14,8 +14,6 @@ interface RelatedArticlesProps {
 const relatedArticlesClass = css`
   margin-block-start: 3rem;
   padding: 1.5rem 1rem;
-  border-top: 2pt solid var(--theme-main-color);
-  background: var(--theme-base-color);
 
   & h2 {
     margin-block: 0 1rem;
@@ -36,15 +34,6 @@ const relatedArticlesClass = css`
 
   & li::before {
     content: "📄 ";
-  }
-
-  & a {
-    color: var(--theme-main-color);
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
   }
 `
 


### PR DESCRIPTION
Hide the related articles section when viewing the index.html page and remove unnecessary styles from the RelatedArticles component.