### PR TITLE
fix: start downloads via body-mounted anchor for desktop Chrome

### DIFF
--- a/app/components/DownloadAdDialog.test.ts
+++ b/app/components/DownloadAdDialog.test.ts
@@ -14,6 +14,7 @@ import DownloadAdDialog, {
   DOWNLOAD_DIALOG_CLASS,
   DOWNLOAD_DIALOG_LABEL,
   DOWNLOAD_FALLBACK_LINK_TEXT,
+  resolveDownloadFilename,
   resolveDownloadHref,
   setupDownloadAdPopup,
 } from './DownloadAdDialog'
@@ -203,6 +204,20 @@ describe('DownloadAdDialog', () => {
     expect(htmlAttr(closeButton, 'type')).toBe('button')
     expect(htmlAttr(closeButton, 'popovertarget')).toBe(DOWNLOAD_AD_POPUP_ID)
     expect(htmlAttr(closeButton, 'popovertargetaction')).toBe('hide')
+  })
+})
+
+describe('resolveDownloadFilename', () => {
+  it('returns an explicit filename when provided', () => {
+    expect(resolveDownloadFilename('https://example.com/a.pdf', 'custom.pdf')).toBe('custom.pdf')
+  })
+
+  it('derives the filename from the href when download is an empty string', () => {
+    expect(resolveDownloadFilename('https://example.com/path/test.pdf', '')).toBe('test.pdf')
+  })
+
+  it('returns undefined when download is omitted', () => {
+    expect(resolveDownloadFilename('https://example.com/test.pdf')).toBeUndefined()
   })
 })
 

--- a/app/components/DownloadAdDialog.tsx
+++ b/app/components/DownloadAdDialog.tsx
@@ -60,6 +60,19 @@ export function resolveDownloadHref(button: HTMLButtonElement, baseUrl?: string)
   }
 }
 
+/** Resolves the `download` attribute value; empty string means "use the URL filename". */
+export function resolveDownloadFilename(href: string, download?: string): string | undefined {
+  if (download === undefined) return undefined
+  if (download.length > 0) return download
+
+  try {
+    const base = typeof document !== 'undefined' ? document.baseURI : 'https://www.nahcnuj.work/'
+    return new URL(href, base).pathname.split('/').filter(Boolean).pop() ?? ''
+  } catch {
+    return ''
+  }
+}
+
 /** Updates the fallback link inside the pre-rendered download popover. */
 export function prepareDownloadAdPopup(popover: HTMLElement, href: string, download?: string): void {
   const fallback = popover.querySelector(`#${DOWNLOAD_AD_FALLBACK_ID}`)
@@ -67,23 +80,30 @@ export function prepareDownloadAdPopup(popover: HTMLElement, href: string, downl
 
   const anchor = fallback as HTMLAnchorElement
   anchor.href = href
-  if (download !== undefined) {
-    anchor.download = download
+  const filename = resolveDownloadFilename(href, download)
+  if (filename !== undefined) {
+    anchor.download = filename
   } else {
     anchor.removeAttribute('download')
   }
 }
 
-/** Programmatically starts a download from a transient anchor element (see E2E download-link tests). */
+/** Programmatically starts a download via a short-lived anchor in `document.body`. */
 export function startDownload(href: string, download?: string, newTab = false): void {
   const anchor = document.createElement('a')
   anchor.href = href
-  if (download !== undefined) anchor.download = download
+  const filename = resolveDownloadFilename(href, download)
+  if (filename !== undefined) {
+    anchor.download = filename
+  }
   if (newTab) {
     anchor.target = '_blank'
     anchor.rel = 'noopener noreferrer'
   }
+  anchor.style.display = 'none'
+  document.body.appendChild(anchor)
   anchor.click()
+  anchor.remove()
 }
 
 function defaultFindDownloadButton(target: EventTarget | null): HTMLButtonElement | null {
@@ -104,7 +124,7 @@ export function setupDownloadAdPopup({
   startDownload: startDownloadFn = startDownload,
   getPopupElement = () => document.querySelector<HTMLElement>(DOWNLOAD_AD_POPUP_SELECTOR),
   findDownloadButton = defaultFindDownloadButton,
-  addClickListener = (handler) => document.addEventListener('click', handler),
+  addClickListener = (handler) => document.addEventListener('click', handler, { capture: true }),
   hasDownloadUi = defaultHasDownloadUi,
   baseUrl,
   gtagFn,

--- a/tests/e2e/download-link.test.ts
+++ b/tests/e2e/download-link.test.ts
@@ -237,7 +237,7 @@ describe('Download link E2E: popup and download flow', () => {
     await page.close()
   }, 30_000)
 
-  it('starts a real download from the button click (transient anchor, no DOM attachment)', async () => {
+  it('starts a real download from the button click', async () => {
     const page = await openFixturePage()
 
     const [download] = await Promise.all([

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,7 +56,8 @@ function devFixturesPlugin(): Plugin {
         }
         res.setHeader('Content-Type', contentTypes[ext] ?? 'application/octet-stream')
         if (ext === '.pdf') {
-          res.setHeader('Content-Disposition', 'inline')
+          const filename = relativePath.split('/').pop() ?? 'download.pdf'
+          res.setHeader('Content-Disposition', `attachment; filename="${filename}"`)
         }
 
         const stream = createReadStream(fixturePath)


### PR DESCRIPTION
## Summary

PC 版 Chrome でダウンロードボタンをクリックしてもファイルが保存されない問題を修正します。ポップアップ（`popovertarget`）は開くのにダウンロードだけ始まらない、という症状でした。

## 原因

`startDownload` が DOM に追加していない一時 `<a>` に対して `click()` だけを呼んでおり、デスクトップ Chrome ではダウンロードが無視されることがあります。

## 変更内容

- `startDownload`: `<a>` を `document.body` に一時追加してから `click()`、直後に削除
- `resolveDownloadFilename`: `download=""` のとき URL からファイル名を明示（フォールバック `<a>` も同様）
- クリック委譲を `capture: true` に変更し、ポップアップ表示より先にダウンロードを開始
- 開発用 fixture ミドルウェア: PDF の `Content-Disposition` を `attachment` に変更

## テスト

- `app/components/DownloadAdDialog.test.ts` — `resolveDownloadFilename` の単体テスト追加
- 既存 E2E `tests/e2e/download-link.test.ts` は引き続きパス想定