### PR TITLE
fix: emit client bundle on pages without honox islands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Verify client script on pages without islands
-        run: grep -E 'src="/static/client-[^"]+\\.js"' dist/index.html
+        run: node scripts/verify-client-script.mjs
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: npm ci --omit dev --ignore-scripts --prefer-offline
       - name: Build
         run: npm run build
+      - name: Verify client script on pages without islands
+        run: grep -E 'src="/static/client-[^"]+\\.js"' dist/essays/download-link.html
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: Verify client script on pages without islands
-        run: grep -E 'src="/static/client-[^"]+\\.js"' dist/essays/download-link.html
+        run: grep -E 'src="/static/client-[^"]+\\.js"' dist/index.html
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/app/components/ClientScript.test.ts
+++ b/app/components/ClientScript.test.ts
@@ -1,0 +1,16 @@
+import { renderToReadableStream } from 'hono/jsx/dom/server'
+import { describe, expect, it } from 'vitest'
+import ClientScript from './ClientScript'
+
+async function renderClientScript(): Promise<string> {
+  const stream = await renderToReadableStream(ClientScript({ async: true }))
+  return new Response(stream).text()
+}
+
+describe('ClientScript', () => {
+  it('renders the dev client entry in non-production builds', async () => {
+    const html = await renderClientScript()
+    expect(html).toContain('src="/app/client.ts"')
+    expect(html).toContain('type="module"')
+  })
+})

--- a/app/components/ClientScript.tsx
+++ b/app/components/ClientScript.tsx
@@ -1,0 +1,40 @@
+type ManifestEntry = {
+  file: string
+}
+
+type ViteManifest = Record<string, ManifestEntry>
+
+const CLIENT_ENTRY = 'app/client.ts'
+
+function loadViteManifest(): ViteManifest | undefined {
+  const modules = import.meta.glob('/dist/.vite/manifest.json', { eager: true }) as Record<
+    string,
+    { default?: ViteManifest }
+  >
+  for (const mod of Object.values(modules)) {
+    if (mod.default) return mod.default
+  }
+  return undefined
+}
+
+function clientBundleSrc(): string | undefined {
+  const manifest = loadViteManifest()
+  const entry = manifest?.[CLIENT_ENTRY]
+  if (!entry) return undefined
+
+  const base = import.meta.env.BASE_URL.endsWith('/')
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`
+  return `${base}${entry.file}`
+}
+
+/** Always emits the global client bundle (honox Script skips pages without islands). */
+export default function ClientScript({ async: asyncLoad = true }: { async?: boolean }) {
+  if (import.meta.env.PROD) {
+    const src = clientBundleSrc()
+    if (!src) return null
+    return <script type="module" {...(asyncLoad ? { async: true } : {})} src={src} />
+  }
+
+  return <script type="module" {...(asyncLoad ? { async: true } : {})} src={`/${CLIENT_ENTRY}`} />
+}

--- a/app/components/RootLayout.tsx
+++ b/app/components/RootLayout.tsx
@@ -1,7 +1,7 @@
 import { css, Style } from 'hono/css'
 import { html } from 'hono/html'
 import type { PropsWithChildren } from 'hono/jsx'
-import { Script } from 'honox/server'
+import ClientScript from './ClientScript'
 import { ADSENSE_CLIENT_ID, THEME_BASE_COLOR, THEME_MAIN_COLOR } from '../lib/site'
 
 interface OpenGraphData {
@@ -181,7 +181,7 @@ const Layout = (props: PropsWithChildren<Meta>) => html`
   ${props.openGraph?.url && html`<link rel="canonical" href="${props.openGraph.url}">`}
   ${props.openGraph && <OpenGraph url={props.openGraph.url} image={props.openGraph.image} />}
   <meta name="twitter:card" content="summary_large_image">
-  ${<Script src="/app/client.ts" async />}
+  ${<ClientScript async />}
   ${<Style>{rootStyle}</Style>}
   <link rel="alternate" type="application/rss+xml" title="www.nahcnuj.work" href="/feed.xml">
   ${import.meta.env.PROD && gtagSnippets.head}\

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run",
     "test:e2e": "vitest run --config vitest.config.e2e.ts",
     "test:vrt": "playwright test",
-    "test:vrt:update": "playwright test --update-snapshots"
+    "test:vrt:update": "playwright test --update-snapshots",
+    "verify:client-script": "node scripts/verify-client-script.mjs"
   },
   "dependencies": {
     "@daiji256/rehype-mathml": "^1.2.2",

--- a/scripts/verify-client-script.mjs
+++ b/scripts/verify-client-script.mjs
@@ -1,0 +1,62 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const CLIENT_SCRIPT_PATTERN = /src="\/static\/client-[^"]+\.js"/
+const ISLAND_PATTERN = /<honox-island/
+/** Honox pages rendered through RootLayout include this style tag. */
+const HONOX_PAGE_PATTERN = /id="hono-css"/
+
+function listHtmlFiles(dir) {
+  const files = []
+  for (const name of readdirSync(dir)) {
+    const path = join(dir, name)
+    const stat = statSync(path)
+    if (stat.isDirectory()) {
+      files.push(...listHtmlFiles(path))
+    } else if (name.endsWith('.html')) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+/** @param {string} distDir */
+export function verifyClientScriptOnIslandFreePages(distDir) {
+  if (!existsSync(distDir)) {
+    throw new Error(`dist directory not found: ${distDir}`)
+  }
+
+  const islandFreePages = listHtmlFiles(distDir).filter((file) => {
+    const html = readFileSync(file, 'utf8')
+    return HONOX_PAGE_PATTERN.test(html) && !ISLAND_PATTERN.test(html)
+  })
+
+  if (islandFreePages.length === 0) {
+    throw new Error('No island-free Honox HTML pages found under dist/')
+  }
+
+  const missing = islandFreePages.filter((file) => !CLIENT_SCRIPT_PATTERN.test(readFileSync(file, 'utf8')))
+
+  return {
+    checked: islandFreePages.length,
+    missing,
+  }
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]
+
+if (isMain) {
+  const distDir = process.argv[2] ?? 'dist'
+  const { checked, missing } = verifyClientScriptOnIslandFreePages(distDir)
+
+  if (missing.length > 0) {
+    console.error('Island-free pages missing client script:')
+    for (const file of missing) {
+      console.error(`  ${file}`)
+    }
+    process.exit(1)
+  }
+
+  console.log(`Verified client script on ${checked} island-free page(s)`)
+}

--- a/tests/client-script.integration.test.ts
+++ b/tests/client-script.integration.test.ts
@@ -1,0 +1,17 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const DOWNLOAD_LINK_HTML = join(process.cwd(), 'dist/essays/download-link.html')
+
+describe('production HTML includes global client script without islands', () => {
+  it('download-link.html references the built client bundle', () => {
+    if (!existsSync(DOWNLOAD_LINK_HTML)) {
+      // Run after `npm run build` to verify SSG output.
+      return
+    }
+
+    const html = readFileSync(DOWNLOAD_LINK_HTML, 'utf8')
+    expect(html).toMatch(/<script[^>]*type="module"[^>]*src="\/static\/client-[^"]+\.js"/)
+  })
+})

--- a/tests/client-script.integration.test.ts
+++ b/tests/client-script.integration.test.ts
@@ -1,17 +1,19 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { verifyClientScriptOnIslandFreePages } from '../scripts/verify-client-script.mjs'
 
-const INDEX_HTML = join(process.cwd(), 'dist/index.html')
+const DIST_DIR = join(process.cwd(), 'dist')
 
 describe('production HTML includes global client script without islands', () => {
-  it('index.html references the built client bundle', () => {
-    if (!existsSync(INDEX_HTML)) {
+  it('every island-free page references the built client bundle', () => {
+    if (!existsSync(DIST_DIR)) {
       // Run after `npm run build` to verify SSG output.
       return
     }
 
-    const html = readFileSync(INDEX_HTML, 'utf8')
-    expect(html).toMatch(/<script[^>]*type="module"[^>]*src="\/static\/client-[^"]+\.js"/)
+    const { checked, missing } = verifyClientScriptOnIslandFreePages(DIST_DIR)
+    expect(checked).toBeGreaterThan(0)
+    expect(missing).toEqual([])
   })
 })

--- a/tests/client-script.integration.test.ts
+++ b/tests/client-script.integration.test.ts
@@ -2,16 +2,16 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
-const DOWNLOAD_LINK_HTML = join(process.cwd(), 'dist/essays/download-link.html')
+const INDEX_HTML = join(process.cwd(), 'dist/index.html')
 
 describe('production HTML includes global client script without islands', () => {
-  it('download-link.html references the built client bundle', () => {
-    if (!existsSync(DOWNLOAD_LINK_HTML)) {
+  it('index.html references the built client bundle', () => {
+    if (!existsSync(INDEX_HTML)) {
       // Run after `npm run build` to verify SSG output.
       return
     }
 
-    const html = readFileSync(DOWNLOAD_LINK_HTML, 'utf8')
+    const html = readFileSync(INDEX_HTML, 'utf8')
     expect(html).toMatch(/<script[^>]*type="module"[^>]*src="\/static\/client-[^"]+\.js"/)
   })
 })

--- a/tests/e2e/download-link.test.ts
+++ b/tests/e2e/download-link.test.ts
@@ -140,6 +140,7 @@ describe('Download link E2E: popup and download flow', () => {
     expect(response.status()).toBe(200)
 
     const html = await response.text()
+    expect(html).toMatch(/<script[^>]*type="module"[^>]*src="\/app\/client\.ts"/)
     expect(html).toMatch(
       new RegExp(`<script[^>]*src="[^"]*adsbygoogle\\.js\\?client=${ADSENSE_CLIENT_ID}"[^>]*>`),
     )


### PR DESCRIPTION
## Summary

ダウンロードボタンを押してもポップアップだけ開き、ファイルが落ちずフォールバックリンクも `href="#"` のままになる問題を修正します。

例: https://www.nahcnuj.work/essays/math/math-for-osaka-university-transfer.html

## 原因

honox の `<Script src="/app/client.ts">` は本番ビルドで `<HasIslands>` 内に出力されます。**island を含まない記事**（多くのエッセイ・数学記事など）では client バンドルが HTML に載らず、`setupDownloadAdPopup` が実行されません。

- ポップアップ表示 → `popovertarget`（ネイティブ HTML）で動作
- ダウンロード開始・フォールバック `href` 更新 → `app/client.ts`（未読込）

#734 で `startDownload` の実装は直していますが、client 自体が読まれないため本番では効果がありませんでした。

## 変更内容

- `ClientScript` コンポーネントを追加し、Vite manifest から **常に** `/static/client-*.js` を出力
- `RootLayout` の honox `<Script>` を `<ClientScript>` に差し替え
- ビルド後 HTML に client が含まれることを CI で検証
- E2E: 開発時は `/app/client.ts` が HTML に含まれることを確認

## テスト

- `app/components/ClientScript.test.ts`
- `tests/client-script.integration.test.ts`（`npm run build` 後）
- CI build ジョブ: `grep` で `dist/essays/download-link.html` を検証