### PR TITLE
chore(deps): bump GitHub Actions dependencies (#716, #724, #725)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -35,7 +35,7 @@ jobs:
       - name: Verify client script on pages without islands
         run: node scripts/verify-client-script.mjs
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-build-dist
           path: dist
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -76,7 +76,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -96,7 +96,7 @@ jobs:
         run: npm run test:e2e
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-test-results-linux
           path: test-results/
@@ -116,7 +116,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -156,7 +156,7 @@ jobs:
         run: npm run test:vrt
       - name: Upload test results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vrt-test-results-${{ matrix.os }}
           path: test-results/
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -195,7 +195,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: setup
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6

--- a/.github/workflows/prepare.yml
+++ b/.github/workflows/prepare.yml
@@ -12,7 +12,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Sync MDX files from Google Drive

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - uses: actions/setup-node@v6
@@ -43,7 +43,7 @@ jobs:
         run: npm ci --omit dev --ignore-scripts --prefer-offline
       - name: Restore dist cache
         id: dist-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: dist
           key: update-dist-${{ runner.os }}-${{ hashFiles('package-lock.json', 'vite.config.ts', 'tsconfig.json', 'app/**/*.ts', 'app/**/*.tsx', 'app/**/*.mdx', 'renderers/**/*.ts', 'public/**') }}
@@ -52,7 +52,7 @@ jobs:
         run: npm run build
       - name: Save dist cache
         if: steps.dist-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: dist
           key: ${{ steps.dist-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Bumps GitHub Actions dependencies to resolve Dependabot PRs #716, #724, and #725.

## Changes
- `actions/checkout` v6 to v7
- `actions/upload-artifact` v4 to v7 in `ci.yml`
- `actions/cache/restore` and `actions/cache/save` v4 to v5 in `update.yml`

## Notes
- Version-pin updates only; no workflow logic changes.
- `prepare.yml` and `update.yml` already used `upload-artifact@v7`; `html5-check.yml` is already current.

Closes #716
Closes #724
Closes #725